### PR TITLE
added multipart specs, finalize to ZMQ::Message, refactored send and …

### DIFF
--- a/examples/publish_subscribe.cr
+++ b/examples/publish_subscribe.cr
@@ -1,4 +1,6 @@
 require "../src/zeromq"
+require "signal"
+
 link = "tcp://127.0.0.1:5555"
 
 begin
@@ -16,6 +18,11 @@ s1.set_socket_option(ZMQ::LINGER, 100)
 s2.set_socket_option(ZMQ::SUBSCRIBE, "")        # receive all
 s3.set_socket_option(ZMQ::SUBSCRIBE, "animals") # receive any starting with this string
 s4.set_socket_option(ZMQ::SUBSCRIBE, "animals.dog")
+
+Signal::INT.trap do
+  [s1, s2, s3, s4].each { |socket| socket.close }
+  ctx.terminate
+end
 
 s1.bind(link)
 s2.connect(link)
@@ -48,8 +55,8 @@ identity = s3.receive_string if s3.more_parts?
 puts "s3 received topic [#{topic}], body [#{body}], identity [#{identity}]"
 
 topic, body, identity = s4.receive_strings
-
 puts "s4 received topic [#{topic}], body [#{body}], identity [#{identity}]"
+
 
 [s1, s2, s3, s4].each do |socket|
   socket.close

--- a/spec/multipart_spec.cr
+++ b/spec/multipart_spec.cr
@@ -2,7 +2,98 @@ require "./spec_helper"
 
 describe ZMQ::Socket do
   context "#send_strings" do
-    pending "correctly handles a multipart message array with 1 element" do
+    it "correctly handles a multipart message with single message send" do
+      data = { "topic", "payload" } # [ "1" ]
+      APIHelper.with_push_pull("tcp://127.0.0.1:5555") do |ctx, sender, receiver|
+        sender.identity = "Test-Sender"
+        sender.send_string(sender.identity, ZMQ::SNDMORE)
+        sender.send_string(data[0], ZMQ::SNDMORE)
+        sender.send_string(data[1])
+        # sender.send_strings(data)
+        sleep 0.1
+        # receiver.receive_strings.should eq(data)
+        receiver.receive_string.should eq(sender.identity)
+        receiver.more_parts?.should be_truthy
+
+        receiver.receive_string.should eq(data[0])
+        receiver.more_parts?.should be_truthy
+
+        receiver.receive_string.should eq(data[1])
+        receiver.more_parts?.should be_falsey
+      end
+    end
+
+    it "correctly handles a multipart message with multiple recieve" do
+      data = { "topic", "payload" } # [ "1" ]
+      APIHelper.with_push_pull("tcp://127.0.0.1:5555") do |ctx, sender, receiver|
+        sender.identity = "Test-Sender"
+        sender.send_string(sender.identity, ZMQ::SNDMORE)
+        sender.send_string(data[0], ZMQ::SNDMORE)
+        sender.send_string(data[1])
+        sleep 0.1
+        receiver.receive_strings.should eq [sender.identity, data[0], data[1]]
+      end
+    end
+
+    it "correctly handles a multipart message with single string array" do
+      data = [ "1" ]
+      APIHelper.with_push_pull("tcp://127.0.0.1:5555") do |ctx, sender, receiver|
+        sender.send_strings(data)
+        sleep 0.1
+        receiver.receive_strings.should eq data
+      end
+    end
+
+    it "delivers between REQ and REP returning an array of messages" do
+      req_data, rep_data = [ "1", "2" ], [ "2", "3" ]
+      APIHelper.with_req_rep("tcp://127.0.0.1:5555") do |ctx, req, rep|
+        req.send_strings(req_data)
+        rep.receive_messages.each_with_index do |msg, idx|
+         msg.to_s.should eq(req_data[idx])
+        end
+
+        rep.send_strings(rep_data)
+        req.receive_messages.each_with_index do |msg, idx|
+          msg.to_s.should eq(rep_data[idx])
+        end
+      end
+    end
+
+    it "delivers between REQ and REP returning an array of strings" do
+      req_data, rep_data = [ "1", "2" ], [ "2", "3" ]
+      APIHelper.with_req_rep do |ctx, req, rep|
+        req.send_strings(req_data)
+        rep.receive_strings.should eq(req_data)
+
+        rep.send_strings(rep_data)
+        req.receive_strings.should eq(rep_data)
+      end
+    end
+  end
+
+  context "with identity" do
+    it "delivers between REQ and REP returning an array of strings with an empty string as the envelope delimiter" do
+      APIHelper.with_req_rep(rep_type: ZMQ::XREP) do |ctx, req, rep|
+        req_data, rep_data = "hello", [ req.identity, "", "ok" ]
+
+        req.send_string(req_data)
+        rep.receive_strings.should eq([ req.identity, "", "hello" ])
+
+        rep.send_strings(rep_data)
+        req.receive_string.should eq(rep_data.last)
+      end
+    end
+
+    it "delivers between REQ and REP returning an array of of messages with an empty string as the envelope delimiter" do
+      APIHelper.with_req_rep(rep_type: ZMQ::XREP) do |ctx, req, rep|
+        req_data, rep_data = "hello", [ req.identity, "", "ok" ]
+
+        req.send_string(req_data)
+        rep.receive_messages.map(&.to_s).should eq([ req.identity, "", "hello" ])
+
+        rep.send_strings(rep_data)
+        req.receive_messages.first.to_s.should eq(rep_data.last)
+      end
     end
   end
 end

--- a/src/zeromq/message.cr
+++ b/src/zeromq/message.cr
@@ -1,7 +1,9 @@
 module ZMQ
   class Message
+    getter? closed
+
     def initialize(message : String? = nil)
-      @pointer = LibZMQ::Msg.new
+      @closed, @pointer = false, LibZMQ::Msg.new
 
       if message
         LibZMQ.msg_init_data(address, message.to_unsafe.as(Void*), message.size, ->(a, b) { LibC.free(b) }, nil)
@@ -22,7 +24,12 @@ module ZMQ
       LibZMQ.msg_size address
     end
 
+    def finalize
+      close
+    end
+
     def close
+      @closed = true
       LibZMQ.msg_close(address)
     end
 


### PR DESCRIPTION
…receive message to use  LibZMQ.msg_recv and  LibZMQ.msg_send as older are deprecated according 0mq docs
