### PR TITLE
Fix set_socket_option pointer issue

### DIFF
--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -96,15 +96,15 @@ module ZMQ
 
     def set_socket_option(name, value)
       rc = case
-           when INT32_SOCKET_OPTIONS.includes?(name) && value.is_a?(Number)
-             value = value.to_i
-             LibZMQ.setsockopt @socket, name, pointerof(value).as(Void*), sizeof(Int32)
-           when INT32_SOCKET_OPTIONS_V4.includes?(name) && value.is_a?(Number)
-             value = value.to_i
-             LibZMQ.setsockopt @socket, name, pointerof(value).as(Void*), sizeof(Int32)
-           when INT64_SOCKET_OPTIONS.includes?(name) && value.is_a?(Number)
-             value = value.to_i64
-             LibZMQ.setsockopt @socket, name, pointerof(value).as(Void*), sizeof(Int64)
+           when INT32_SOCKET_OPTIONS.includes?(name) && value.is_a?(Int32)
+             value32 = value.to_i
+             LibZMQ.setsockopt(@socket, name, pointerof(value32).as(Void*), sizeof(Int32))
+           when INT32_SOCKET_OPTIONS_V4.includes?(name) && value.is_a?(Int32)
+             value32 = value.to_i
+             LibZMQ.setsockopt @socket, name, pointerof(value32).as(Void*), sizeof(Int32)
+           when INT64_SOCKET_OPTIONS.includes?(name) && value.is_a?(Int64)
+             value64 = value.to_i64
+             LibZMQ.setsockopt(@socket, name, pointerof(value64).as(Void*), sizeof(Int64))
            when STRING_SOCKET_OPTIONS.includes?(name) && value.is_a?(String)
              LibZMQ.setsockopt @socket, name, value.to_unsafe.as(Void*), value.size
            when STRING_SOCKET_OPTIONS_V4.includes?(name) && value.is_a?(String)


### PR DESCRIPTION
> I found an issue when setting socket options in set_socket_option method.

This is an example to reproduce the error

```
require "zeromq"

context = ZMQ::Context.new
num_requests = 1
link = "tcp://127.0.0.1:5555"

close = Channel(Nil).new

start = Time.now

spawn do
  puts "Start server"
  responder = context.socket(ZMQ::REP)
  responder.bind(link)

  num_requests.times do
    Fiber.yield
    message = responder.receive_message
    responder.send_message(message)
  end

  responder.close
end

spawn do
  puts "Start client"
  requester = context.socket(ZMQ::REQ)
  puts "--- Current ZMQ::RCVTIMEO value ---"
  pp requester.get_socket_option(ZMQ::RCVTIMEO)
  puts "--- Setting ZMQ::RCVTIMEO to 4000 ---"
  pp requester.set_socket_option(ZMQ::RCVTIMEO, 4000)
  puts "--- ZMQ::RCVTIMEO new value"
  pp requester.get_socket_option(ZMQ::RCVTIMEO)
  requester.connect(link)

  num_requests.times do |index|
    requester.send_string("Hello")
    Fiber.yield
    pp requester.receive_string
  end

  requester.close
  close.send(nil)
end
close.receive
context.terminate

seconds = (Time.now - start).total_seconds
puts "Messages per second: #{(num_requests * 2) / seconds.to_f}"
puts "Total seconds: #{seconds}"
```

This is the result

Start server
Start client
--- Current ZMQ::RCVTIMEO value ---
requester.get_socket_option(ZMQ::RCVTIMEO) # => -1
--- Setting ZMQ::RCVTIMEO to 4000 ---
requester.set_socket_option(ZMQ::RCVTIMEO, 4000) # => true
--- ZMQ::RCVTIMEO new value
requester.get_socket_option(ZMQ::RCVTIMEO) # => **160**
requester.receive_string # => "Hello"
Messages per second: 423.728813559322
Total seconds: 0.00472

It sets a value different than the one it is expected.