### PR TITLE
0.31.0, then 0.33.0, and add Deregister

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,8 @@
 name: zeromq
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - Benoist Claassen <benoist.claassen@gmail.com>
+  - digitalextremist <code@extremist.digital>
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: zeromq
-version: 0.2.0
+version: 0.2.1
 
 authors:
   - Benoist Claassen <benoist.claassen@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: zeromq
-version: 0.1.1
+version: 0.1.2
 
 authors:
   - Benoist Claassen <benoist.claassen@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: zeromq
-version: 0.1.2
+version: 0.1.3
 
 authors:
   - Benoist Claassen <benoist.claassen@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: zeromq
-version: 0.2.1
+version: 0.3.0
 
 authors:
   - Benoist Claassen <benoist.claassen@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: zeromq
-version: 0.1.3
+version: 0.2.0
 
 authors:
   - Benoist Claassen <benoist.claassen@gmail.com>

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -22,9 +22,9 @@ module APIHelper
   end
 
   def connect_to_inproc(socket : ZMQ::Socket, endpoint : String, timeout = 3)
-    started = Time.now
+    started = Time.local
     loop do
-      break if socket.connect(endpoint) || (started - Time.now).seconds > timeout # ZMQ::Util.resultcode_ok?(rc)
+      break if socket.connect(endpoint) || (started - Time.local).seconds > timeout # ZMQ::Util.resultcode_ok?(rc)
     end
   end
 

--- a/src/zeromq/poller.cr
+++ b/src/zeromq/poller.cr
@@ -60,7 +60,7 @@ class ZMQ::Poller
     register(socket, POLLOUT)
   end
 
-  def deregister( socket : Socket, type = POLLIN | POLLOUT)
+  def deregister(socket : Socket, type = POLLIN | POLLOUT)
     @poll_items.delete({socket, type})
   end
 

--- a/src/zeromq/poller.cr
+++ b/src/zeromq/poller.cr
@@ -59,4 +59,16 @@ class ZMQ::Poller
   def register_writable(socket)
     register(socket, POLLOUT)
   end
+
+  def deregister( socket : Socket, type = POLLIN | POLLOUT)
+    @poll_items.delete({socket, type})
+  end
+
+  def deregister_readable(socket : Socket)
+    deregister(socket, POLLIN)
+  end
+
+  def deregister_writable(socket : Socket)
+    register(socket, POLLOUT)
+  end
 end

--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -42,8 +42,8 @@ module ZMQ
     getter socket
     getter name : String
     getter? closed
-    @read_event : Crystal::Event | Crystal::ThreadLocalValue(Crystal::Event) | Nil
-    @write_event : Crystal::Event | Crystal::ThreadLocalValue(Crystal::Event) | Nil
+    @read_event : Crystal::ThreadLocalValue(Crystal::Event)?
+    @write_event : Crystal::ThreadLocalValue(Crystal::Event)?
 
     def self.create(context : Context, type : Int32, message_type = Message) : self
       new context, type, message_type
@@ -304,9 +304,9 @@ module ZMQ
     end
 
     def close
-      @read_event.try &.free
+      @read_event.get &.try &.free
       @read_event = nil
-      @write_event.try &.free
+      @write_event.get &.try &.free
       @write_event = nil
       @closed = true
       LibZMQ.close @socket

--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -311,7 +311,7 @@ module ZMQ
       LibZMQ.close @socket
     end
 
-    #de Copied from ::IO itself, since IO::Evented does not have this:
+    # Copied from ::IO itself, since IO::Evented does not have this:
     protected def check_open
       raise IO::Error.new "Closed stream" if closed?
     end

--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -42,8 +42,8 @@ module ZMQ
     getter socket
     getter name : String
     getter? closed
-    @read_event : Crystal::Event?
-    @write_event : Crystal::Event?
+    @read_event : Crystal::Event | Crystal::ThreadLocalValue(Crystal::Event) | Nil
+    @write_event : Crystal::Event | Crystal::ThreadLocalValue(Crystal::Event) | Nil
 
     def self.create(context : Context, type : Int32, message_type = Message) : self
       new context, type, message_type

--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -305,14 +305,15 @@ module ZMQ
     end
 
     def close
-      @read_event.each &.free
-      @read_event.clear
-
-      @write_event.each &.free
-      @write_event.clear
-
+      @read_event.consume_each &.free
+      @write_event.consume_each &.free
       @closed = true
       LibZMQ.close @socket
+    end
+
+    #de Copied from ::IO itself, since IO::Evented does not have this:
+    protected def check_open
+      raise IO::Error.new "Closed stream" if closed?
     end
   end
 end

--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -305,11 +305,6 @@ module ZMQ
     end
 
     def close
-      #de @read_event.try &.free
-      #de @read_event = nil
-      #de @write_event.try &.free
-      #de @write_event = nil
-
       @read_event.each &.free
       @read_event.clear
 

--- a/src/zeromq/version.cr
+++ b/src/zeromq/version.cr
@@ -1,5 +1,5 @@
 module ZMQ
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 
   def self.version
     LibZMQ.version(out major, out minor, out patch)

--- a/src/zeromq/version.cr
+++ b/src/zeromq/version.cr
@@ -1,5 +1,5 @@
 module ZMQ
-  VERSION = "0.1.0"
+  VERSION = "0.2.1"
 
   def self.version
     LibZMQ.version(out major, out minor, out patch)


### PR DESCRIPTION
This is a round-up of three sets of changes accumulating in my fork:

- [x] Make `0.31.0` compatible ( instead of #15 )
- [x] Add `deregister` support to `ZMQ::Poller` per #16 
- [x] Make `0.33.0` compatible per #18 