### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,12 @@
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.9
-    - g++-4.9
-    - uuid-dev
-    - libssl-dev
-
 language: crystal
 
-env:
- - ZMQ="4.2.2"
+before_install: make build
 
-before_install:
- - export CXX=g++-4.9
- - export CC=gcc-4.9
- - mkdir ldlocal
- - export LDHACK=`pwd`/ldlocal
- - export LDFLAGS=-L$LDHACK/lib
- - export CFLAGS=-I$LDHACK/include
- - export LD_RUN_PATH=$LDHACK/lib
- - export LD_LIBRARY_PATH=$LDHACK/lib
- - export LIBRARY_PATH=$LDHACK/lib
- - export PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig
- - echo $PKG_CONFIG_PATH
- - wget https://github.com/zeromq/libzmq/releases/download/v$ZMQ/zeromq-$ZMQ.tar.gz
- - tar xzvf zeromq-$ZMQ.tar.gz
- - sudo apt-get update
- - sudo apt-get install -y libtool pkg-config build-essential autoconf automake uuid-dev
-
- - cd zeromq-$ZMQ
- - ./configure
- - sudo make
- - sudo make install
- - cd ..
+install:
+  - shards install
 
 script:
-  crystal spec
+  - bin/ameba
+
+sudo: required
+email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install: make build
 install:
   - shards install
 
-script:
-  - bin/ameba
+# script:
+#   - bin/ameba
 
 sudo: required
 email: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all
+all:
+	@echo Nothing to do
+
+build:
+	# build zeromq
+	git clone --depth=1 https://github.com/zeromq/libzmq.git
+	mkdir -p zeromq/build; \
+	cd zeromq/build; \
+	cmake ..; \
+	make; \
+	sudo make install

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,5 @@ build:
 	mkdir -p libzmq/build; \
 	cd libzmq/build; \
 	cmake ..; \
-	make; \
+	make -j8; \
 	sudo make install

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ all:
 build:
 	# build zeromq
 	git clone --depth=1 https://github.com/zeromq/libzmq.git
-	mkdir -p zeromq/build; \
-	cd zeromq/build; \
+	mkdir -p libzmq/build; \
+	cd libzmq/build; \
 	cmake ..; \
 	make; \
 	sudo make install

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ build:
 	git clone --depth=1 https://github.com/zeromq/libzmq.git
 	mkdir -p libzmq/build; \
 	cd libzmq/build; \
-	cmake ..; \
+	cmake -DCMAKE_INSTALL_PREFIX=/usr ..; \
 	make -j8; \
 	sudo make install

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ build:
 	git clone --depth=1 https://github.com/zeromq/libzmq.git
 	mkdir -p libzmq/build; \
 	cd libzmq/build; \
-	cmake -DCMAKE_INSTALL_PREFIX=/usr ..; \
+	cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTS=OFF -DWITH_PERF_TOOL=OFF -DCMAKE_BUILD_TYPE="Release" ..; \
 	make -j8; \
 	sudo make install

--- a/README.md
+++ b/README.md
@@ -15,25 +15,15 @@ dependencies:
     github: crystal-community/zeromq-crystal
 ```
 
-
 ## Usage
 
-
 ```crystal
-require "zeromq"
-```
-
-```crystal
+require "../src/zeromq"
 
 # Simple server
 context = ZMQ::Context.new
 server = context.socket(ZMQ::REP)
 server.bind("tcp://127.0.0.1:5555")
-
-loop do
-    puts server.receive_string
-    server.send_string("Got it")
-end
 
 # Simple client
 context = ZMQ::Context.new
@@ -41,6 +31,10 @@ client = context.socket(ZMQ::REQ)
 client.connect("tcp://127.0.0.1:5555")
 
 client.send_string("Fetch")
+
+puts server.receive_string
+server.send_string("Got it")
+
 puts client.receive_string
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dependencies:
 ## Usage
 
 ```crystal
-require "../src/zeromq"
+require "zeromq"
 
 # Simple server
 context = ZMQ::Context.new

--- a/examples/basic.cr
+++ b/examples/basic.cr
@@ -1,0 +1,18 @@
+require "../src/zeromq"
+
+# Simple server
+context = ZMQ::Context.new
+server = context.socket(ZMQ::REP)
+server.bind("tcp://127.0.0.1:5555")
+
+# Simple client
+context = ZMQ::Context.new
+client = context.socket(ZMQ::REQ)
+client.connect("tcp://127.0.0.1:5555")
+
+client.send_string("Fetch")
+
+puts server.receive_string
+server.send_string("Got it")
+
+puts client.receive_string

--- a/shard.yml
+++ b/shard.yml
@@ -1,8 +1,14 @@
 name: zeromq
 version: 0.3.0
 
+crystal: 0.33.0
+license: MIT
+
 authors:
   - Benoist Claassen <benoist.claassen@gmail.com>
   - digitalextremist <code@extremist.digital>
 
-license: MIT
+development_dependencies:
+  ameba:
+    github: crystal-ameba/ameba
+    version: ~> 0.11.0


### PR DESCRIPTION
I cleaned up the travis.yml ( simplified ).
libzmq is cloned and built with cmake now.

The error currently breaking travis is that the shared library could not be found, which I addressed by installing zeromq to a location where crystal spec can find it.

That being said, this crystal binding should be built with the static lib to remove that problem entirely.

Also, now that travis can run, crystal spec will timeout on a test.