### PR TITLE
Crystal 0.34 compatibility

### DIFF
--- a/examples/client_server.cr
+++ b/examples/client_server.cr
@@ -6,7 +6,7 @@ link = "tcp://127.0.0.1:5555"
 
 close = Channel(Nil).new
 
-start = Time.now
+start = Time.monotonic
 
 spawn do
   puts "Start server"
@@ -40,6 +40,6 @@ end
 close.receive
 context.terminate
 
-seconds = (Time.now - start).total_seconds
+seconds = (Time.monotonic - start).total_seconds
 puts "Messages per second: #{(num_requests * 2) / seconds.to_f}"
 puts "Total seconds: #{seconds}"

--- a/examples/local_lat_poll.cr
+++ b/examples/local_lat_poll.cr
@@ -28,7 +28,7 @@ poller = ZMQ::Poller.new
 poller.register_readable(s2)
 poller.register_readable(s1)
 
-start_time = Time.now
+start_time = Time.monotonic
 
 # kick it off
 message = ZMQ::Message.new("a" * message_size)
@@ -47,8 +47,8 @@ until i == 0
   end
 end
 
-span = (Time.now - start_time)
-latency = span.ticks.to_f / roundtrip_count / 2.0
+span = (Time.monotonic - start_time)
+latency = span.total_microseconds / roundtrip_count / 2.0
 
 puts "mean latency: %.3f [us]" % latency
 puts "messages per second: %.3f " % (roundtrip_count / span.total_seconds)

--- a/examples/push_pull.cr
+++ b/examples/push_pull.cr
@@ -6,7 +6,7 @@ link = "tcp://127.0.0.1:5555"
 
 close = Channel(Nil).new
 
-start = Time.now
+start = Time.monotonic
 
 spawn do
   puts "Start server"
@@ -40,6 +40,6 @@ end
 close.receive
 context.terminate
 
-seconds = (Time.now - start).total_seconds
+seconds = (Time.monotonic - start).total_seconds
 puts "Messages per second: %.3f" % (num_requests / seconds.to_f)
 puts "Total seconds: #{seconds}"

--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -106,7 +106,7 @@ module ZMQ
       loop do
         rc = LibZMQ.msg_send(message.address, @socket, flags | ZMQ::DONTWAIT)
         if rc == -1
-          if Util.errno == Errno::EAGAIN
+          if Util.errno == Errno::EAGAIN.to_i
             wait_writable
           else
             raise Util.error_string
@@ -137,7 +137,7 @@ module ZMQ
         message = @message_type.new
         rc = LibZMQ.msg_recv(message.address, @socket, flags | ZMQ::DONTWAIT)
         if rc == -1
-            if Util.errno == Errno::EAGAIN
+            if Util.errno == Errno::EAGAIN.to_i
               wait_readable
             else
               raise Util.error_string
@@ -170,7 +170,7 @@ module ZMQ
         message = @message_type.new
         rc = LibZMQ.msg_recv(message.address, @socket, flags | ZMQ::DONTWAIT)
         if rc == -1
-          if Util.errno == Errno::EAGAIN
+          if Util.errno == Errno::EAGAIN.to_i
             wait_readable
           else
             raise Util.error_string


### PR DESCRIPTION
This PR brings compatibility with Crystal 0.34.

- As `Errno` is now an enum, there was an issue comparing `Errno.value` (which now returns an enum value) with `ZMQ::Util.errno` which still returns an integer, leading to raised exceptions.
- I also updated broken examples that was not compatible with recent crystals (use of `Time.now` and `Time::Span.ticks`).