### PR TITLE
Update to work with Crystal 1.8

### DIFF
--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -32,6 +32,10 @@ class Crystal::LibEvent::EventLoop
     end
     event
   end
+
+  def stop_loop
+    event_base.loop_break
+  end
 end
 
 module ZMQ

--- a/src/zeromq/socket.cr
+++ b/src/zeromq/socket.cr
@@ -1,5 +1,3 @@
-require "crystal/thread_local_value"
-
 # EventLoop support
 # Crystal Update for zmq sockets
 class Crystal::LibEvent::EventLoop


### PR DESCRIPTION
Changes to Events in Crystal made zeromq no longer work. This is the update to work with the latest Crystal 1.8.